### PR TITLE
feat: Set RoutinesScreen as default homepage for improved UX

### DIFF
--- a/lib/screens/main_navigation.dart
+++ b/lib/screens/main_navigation.dart
@@ -15,7 +15,7 @@ class MainNavigation extends StatefulWidget {
 }
 
 class _MainNavigationState extends State<MainNavigation> {
-  int _currentIndex = 0;
+  int _currentIndex = 1;
   bool _isLoggingOut = false;
 
   final List<Widget> _screens = const [


### PR DESCRIPTION
## Description
This PR updates the default home screen of the application to the “Routines” screen.

## Context
The goal is to improve the initial user experience by directly presenting the Routines section, which is one of the most used and relevant functionalities to start interacting with the application. This PR updates the default home screen of the application to the RoutinesScreen.

## How to test?
1. Open the application.
2. Check that the first visible screen after login is the “Routines” screen.