### PR TITLE
feat: Add weekly training statistics and totals

### DIFF
--- a/lib/models/routine_history.dart
+++ b/lib/models/routine_history.dart
@@ -1,12 +1,14 @@
 class RoutineHistory {
   final String routineName;
   final DateTime date;
+  final int duration;
   final int completedExercises;
   final int totalExercises;
 
   RoutineHistory({
     required this.routineName,
     required this.date,
+    required this.duration,
     required this.completedExercises,
     required this.totalExercises,
   });

--- a/lib/screens/routines_screen.dart
+++ b/lib/screens/routines_screen.dart
@@ -115,8 +115,8 @@ class _RoutinesScreenState extends State<RoutinesScreen>
                   '${_routines.length}',
                   Icons.fitness_center,
                 ),
-                _buildStatItem('Esta semana', '4', Icons.calendar_today),
-                _buildStatItem('Tiempo total', '3h 15m', Icons.timer),
+                _buildStatItem('Esta semana', _getNumberOfExercisesInTheWeek(), Icons.calendar_today),
+                _buildStatItem('Tiempo total', _getTotalTime(), Icons.timer),
               ],
             ),
           ),
@@ -143,6 +143,19 @@ class _RoutinesScreenState extends State<RoutinesScreen>
         label: Text('Nueva Rutina'),
       ),
     );
+  }
+
+  String _getNumberOfExercisesInTheWeek() {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day - 7);
+    final firstDayOfWeek = today.subtract(Duration(days: today.weekday - 1));
+    return _history.where((element) => !DateTime(element.date.year, element.date.month, element.date.day).isBefore(firstDayOfWeek)).length.toString();
+  }
+
+  String _getTotalTime() {
+    return _history.fold<int>(0, (previousValue, element) {
+      return previousValue + element.duration;
+    }).toString();
   }
 
   Widget _buildStatItem(String label, String value, IconData icon) {
@@ -535,6 +548,7 @@ class _RoutinesScreenState extends State<RoutinesScreen>
                 RoutineHistory(
                   routineName: routine['name'],
                   date: DateTime.now(),
+                  duration: _getRoutineDuration(routine['duration'], total, completed),
                   completedExercises: completed,
                   totalExercises: total,
                 ),
@@ -544,6 +558,10 @@ class _RoutinesScreenState extends State<RoutinesScreen>
         ),
       ),
     );
+  }
+
+  int _getRoutineDuration(String duration, int total, int completed) {
+    return ((int.parse(duration.split(' ')[0]) / total) * completed).round();
   }
 
   Future<void> _showCreateRoutineSheet(BuildContext context) async {


### PR DESCRIPTION
## Description.
This PR adds key training statistics:
1. number of workouts performed in the current week.
2. Total cumulative duration of all workouts.

## Context
The goal is to provide users with a quick and clear way to view their progress by allowing them to easily track their weekly consistency and overall commitment to training over time.

## How to test?
Completing training routines